### PR TITLE
feat: Dockerize weather api app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use the official Go image as a base
+FROM golang:1.22.3 as builder
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the Go module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the entire source code into the container
+COPY . .
+
+# Build the Go application
+RUN CGO_ENABLED=0 GOOS=linux go build -o weather-api .
+
+# Create a minimal image for running the application
+FROM alpine:latest
+
+# Set the working directory
+WORKDIR /root/
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/weather-api .
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Command to run the executable
+CMD ["./weather-api"]

--- a/README.md
+++ b/README.md
@@ -28,19 +28,14 @@ go build -o weather-api
 ```
 
 ## Running the Application
-1. Build the Docker image:  
-   ```docker-compose build```
-2. Start Redis with Docker Compose  
-   The application uses Redis for caching. Use Docker Compose to start the Redis container:  
-   ```docker-compose up -d```
-3. Start the application:  
-   ```./weather-api```
+1. Start the app:  
+   ```docker-compose up --build```
  
 ## Usage
 1. Access the app:
    Open your web browser and navigate to:  
    ```http://localhost:8080/weather?address=sao%20paulo```  
-   Or test via cURL:  
+   Or open a new terminal and test it via cURL :  
    ```curl -v "http://localhost:8080/weather?address=london"```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 services:
+  weather-api:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - WEATHER_API_KEY=${WEATHER_API_KEY}
+    depends_on:
+      - redis
   redis:
-    image: redis:latest
-    container_name: redis-server
+    image: redis:alpine
     ports:
       - "6379:6379" # Map Redis port

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 
 	// Initialize Redis client
-	redisAddr := "localhost:6379" // Replace with your Redis server address
+	redisAddr := "redis:6379" // Replace with your Redis server address
 	repository.InitRedis(redisAddr)
 
 	r := mux.NewRouter()


### PR DESCRIPTION
## What does it do?
 This PR introduces changes to dockerize the Weather API application, allowing it to run seamlessly as a containerized service. The configuration updates facilitate efficient communication between the Weather API and Redis, ensuring better performance and scalability.

## Changes Made:

1. **Dockerized the Application**:
   - Added a `Dockerfile` to define how the Weather API application is built and run inside a Docker container.
   - Created a `docker-compose.yml` file to manage multi-container deployment, including the Redis service required for caching.

2. **Updated Docker Compose Configuration**:
   - Defined services for both the Weather API and Redis in `docker-compose.yml`.
   - Set the Redis service to use the official Redis image and configured it to run on the default port `6379`.

3. **Changed Hostname for Redis Connection**:
   - Updated the Weather API application code to connect to the Redis service using the service name (`redis:6379`), ensuring proper resolution within the Docker network.

4. **Updated Steps for Running the Application**:
   - Revised the README documentation to reflect the new steps required to build and run the application using Docker and Docker Compose. 
   - Included instructions for starting the entire application stack with a single command and highlighted the environment variable for the Weather API key.

## Updated README Sections:

- **Installation**: Added instructions for building and running the application using Docker Compose.
- **Running the Application**: Updated the steps to emphasize using `docker-compose up` to start both the Weather API and Redis services, removing the need for separate commands.
- **Usage**: Clarified how to access the application through the web browser or cURL once the services are running.

## How to Build and Run the Application in Docker:
Follow instructions in the README file.