### PR TITLE
refactor: change service name to avoid redundancy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  weather-api:
+  app:
     build: .
     ports:
       - "8080:8080"


### PR DESCRIPTION
## What does it do?
**Change the service name**: Rename the service in the docker-compose.yml file to avoid redundancy

## Why?
The image name weather-api-weather-api follows the naming convention automatically applied by Docker Compose when it builds or runs services defined in your docker-compose.yml file. The format is:
```<project-name>-<service-name>```
 
Here’s why it’s named weather-api-weather-api:

1. weather-api: The first part corresponds to the project name. By default, Docker Compose derives the project name from the directory containing the docker-compose.yml file. If your project directory is named weather-api, this becomes the project name. You can override this name using the -p option or a COMPOSE_PROJECT_NAME environment variable.

2. weather-api: The second part corresponds to the service name in the docker-compose.yml file. If your service is named weather-api, Docker Compose appends it to the project name.

After the change, the name will be like this: 
![image](https://github.com/user-attachments/assets/b276a676-c90f-426f-bfd4-59f066c27224)
